### PR TITLE
Fix account number regex

### DIFF
--- a/src/ofxstatement/plugins/sparkasse_de.py
+++ b/src/ofxstatement/plugins/sparkasse_de.py
@@ -54,7 +54,7 @@ class SparkasseParser(StatementParser[str]):
             for line in lines(page):
                 # TODO: read initial and final balance
                 #print(line, ";")
-                regex_account_id = r"Girokonto (?P<acct_no>\d+)"
+                regex_account_id = r"(?P<acct_no>\d+), DE\d{2} (\d{4} ){4}\d{2}"
                 m = re.search(regex_account_id, line)
                 if m is not None:
                     self.account_no = m.group("acct_no")


### PR DESCRIPTION
Previously this worked only when the account was actually named "Girokonto". Now it works with any account name (e.g. "Das Junge Konto") and is matched based on the IBAN following right after it.